### PR TITLE
v0.17.3

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -7,19 +7,25 @@ on:
 # Every Friday at 22:00 - rerun pipeline to check for dependency-based issues
     - cron: '0 22 * * 5'
 
+permissions:
+  actions:  write
+  contents: write
+  pages:    write
+  id-token: write
+
 jobs:
   Prepare:
-    uses: pyTooling/Actions/.github/workflows/PrepareJob.yml@r6
+    uses: pyTooling/Actions/.github/workflows/PrepareJob.yml@r7
 
   ConfigParams:
-    uses: pyTooling/Actions/.github/workflows/ExtractConfiguration.yml@r6
+    uses: pyTooling/Actions/.github/workflows/ExtractConfiguration.yml@r7
 
   Java-Ant-JUnit4:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: ☕ Set up JDK 21 for x64
         uses: actions/setup-java@v5
         with:
@@ -42,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🔧 Install dependencies
         run: sudo apt-get install -y --no-install-recommends ninja-build
       - name: 🛠 Run CMake
@@ -71,7 +77,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🐍 Setup Python 3.12
         uses: actions/setup-python@v6
         with:
@@ -91,20 +97,20 @@ jobs:
           path: examples/Python/pytest/*.xml
 
   UnitTestingParams:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r6
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r7
     with:
       package_namespace:   'pyEDAA'
       package_name:        'Reports'
       python_version_list: '3.11 3.12 3.13 3.14 pypy-3.11'
 
   AppTestingParams:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r6
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r7
     with:
       name: pyEDAA.Reports
       python_version_list: ""   # use latest Python version
 
   UnitTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r6
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r7
     needs:
       - ConfigParams
       - UnitTestingParams
@@ -118,7 +124,7 @@ jobs:
       coverage_sqlite_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r6
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r7
     needs:
       - ConfigParams
       - UnitTestingParams
@@ -128,7 +134,7 @@ jobs:
       html_artifact:  ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   CodeQuality:
-    uses: pyTooling/Actions/.github/workflows/CheckCodeQuality.yml@r6
+    uses: pyTooling/Actions/.github/workflows/CheckCodeQuality.yml@r7
     needs:
       - UnitTestingParams
     with:
@@ -139,7 +145,7 @@ jobs:
       artifact:          CodeQuality
 
   DocCoverage:
-    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r6
+    uses: pyTooling/Actions/.github/workflows/CheckDocumentation.yml@r7
     needs:
       - UnitTestingParams
     with:
@@ -147,7 +153,7 @@ jobs:
       directory:      ${{ needs.UnitTestingParams.outputs.package_directors }}
 
   Package:
-    uses: pyTooling/Actions/.github/workflows/Package.yml@r6
+    uses: pyTooling/Actions/.github/workflows/Package.yml@r7
     needs:
       - UnitTestingParams
     with:
@@ -155,7 +161,7 @@ jobs:
       artifact:       ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
 
   AppTesting:
-    uses: pyTooling/Actions/.github/workflows/ApplicationTesting.yml@r6
+    uses: pyTooling/Actions/.github/workflows/ApplicationTesting.yml@r7
     needs:
       - AppTestingParams
       - UnitTestingParams
@@ -169,7 +175,7 @@ jobs:
       apptest_xml_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).apptesting_xml }}
 
   PublishCoverageResults:
-    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r6
+    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r7
     needs:
       - ConfigParams
       - UnitTestingParams
@@ -187,7 +193,7 @@ jobs:
       CODACY_TOKEN:  ${{ secrets.CODACY_TOKEN }}
 
   PublishTestResults:
-    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@r6
+    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@r7
     needs:
       - ConfigParams
       - UnitTestingParams
@@ -203,7 +209,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   Documentation:
-    uses: pyTooling/Actions/.github/workflows/SphinxDocumentation.yml@r6
+    uses: pyTooling/Actions/.github/workflows/SphinxDocumentation.yml@r7
     needs:
       - UnitTestingParams
       - ConfigParams
@@ -218,7 +224,7 @@ jobs:
       latex_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_latex }}
 
   IntermediateCleanUp:
-    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r6
+    uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@r7
     needs:
       - UnitTestingParams
       - PublishCoverageResults
@@ -228,7 +234,7 @@ jobs:
       xml_unittest_artifacts_prefix:    ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}-
 
   PDFDocumentation:
-    uses: pyTooling/Actions/.github/workflows/LaTeXDocumentation.yml@r6
+    uses: pyTooling/Actions/.github/workflows/LaTeXDocumentation.yml@r7
     needs:
       - UnitTestingParams
       - Documentation
@@ -239,7 +245,7 @@ jobs:
       can-fail:       'true'
 
   PublishToGitHubPages:
-    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@r6
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@r7
     needs:
       - UnitTestingParams
       - Documentation
@@ -252,7 +258,7 @@ jobs:
       typing:   ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   TriggerTaggedRelease:
-    uses: pyTooling/Actions/.github/workflows/TagReleaseCommit.yml@r6
+    uses: pyTooling/Actions/.github/workflows/TagReleaseCommit.yml@r7
     needs:
       - Prepare
       - UnitTesting
@@ -270,7 +276,7 @@ jobs:
     secrets: inherit
 
   ReleasePage:
-    uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@r6
+    uses: pyTooling/Actions/.github/workflows/PublishReleaseNotes.yml@r7
     needs:
       - Prepare
       - UnitTesting
@@ -287,7 +293,7 @@ jobs:
     secrets: inherit
 
   PublishOnPyPI:
-    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r6
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r7
     needs:
       - UnitTestingParams
       - ReleasePage
@@ -300,7 +306,7 @@ jobs:
       PYPI_TOKEN:     ${{ secrets.PYPI_TOKEN }}
 
   ArtifactCleanUp:
-    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r6
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r7
     needs:
       - UnitTestingParams
       - UnitTesting

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -39,7 +39,7 @@ jobs:
       - name: List generated XML reports
         run: ls -lAh examples/Java/JUnit/build/*.xml
       - name: 📤 Upload JUnit XML files as artifact
-        uses: pyTooling/upload-artifact@v5
+        uses: pyTooling/upload-artifact@v6
         with:
           name: Java-Ant-JUnit4
           path: examples/Java/JUnit/build/*.xml
@@ -68,7 +68,7 @@ jobs:
         run: |
           ls -lAh examples/Cpp/GoogleTest/*.xml
       - name: 📤 Upload JUnit XML files as artifact
-        uses: pyTooling/upload-artifact@v5
+        uses: pyTooling/upload-artifact@v6
         with:
           name: Cpp-GoogleTest
           path: examples/Cpp/GoogleTest/*.xml
@@ -91,7 +91,7 @@ jobs:
       - name: List generated XML reports
         run: ls -lAh examples/Python/pytest/*.xml
       - name: 📤 Upload JUnit XML files as artifact
-        uses: pyTooling/upload-artifact@v5
+        uses: pyTooling/upload-artifact@v6
         with:
           name: Python-pytest
           path: examples/Python/pytest/*.xml

--- a/dist/requirements.txt
+++ b/dist/requirements.txt
@@ -1,2 +1,2 @@
-wheel ~= 0.45
+wheel ~= 0.45.0
 twine ~= 6.2

--- a/doc/Dependency.rst
+++ b/doc/Dependency.rst
@@ -7,15 +7,15 @@ Dependencies
    :alt: Libraries.io status for latest release
    :height: 22
    :target: https://libraries.io/github/edaa-org/pyEDAA.Reports
-.. |img-Reports-req-status| image:: https://img.shields.io/requires/github/pyEDAA/pyEDAA.Reports
-   :alt: Requires.io
+.. |img-Reports-vul-status| image:: https://img.shields.io/snyk/vulnerabilities/github/edaa-org/pyEDAA.Reports
+   :alt: Snyk Vulnerabilities for GitHub Repo
    :height: 22
-   :target: https://requires.io/github/edaa-org/pyEDAA.Reports/requirements/?branch=main
+   :target: https://img.shields.io/snyk/vulnerabilities/github/edaa-org/pyEDAA.Reports
 
 +------------------------------------------+------------------------------------------+
-| `Libraries.io <https://libraries.io/>`_  | `Requires.io <https://requires.io/>`_    |
+| `Libraries.io <https://libraries.io/>`_  | Vulnerabilities Summary                  |
 +==========================================+==========================================+
-| |img-Reports-lib-status|                 | |img-Reports-req-status|                 |
+| |img-Reports-lib-status|                 | |img-Reports-vul-status|                 |
 +------------------------------------------+------------------------------------------+
 
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@
 
 # Enforce latest version on ReadTheDocs
 sphinx ~= 8.2
-docutils ~= 0.21
+docutils ~= 0.21.0
 docutils_stubs ~= 0.0.22
 
 # ReadTheDocs Theme
@@ -10,9 +10,9 @@ sphinx_rtd_theme ~= 3.0
 
 # Sphinx Extenstions
 sphinxcontrib-mermaid ~= 1.0
-sphinxcontrib-autoprogram ~= 0.1
+sphinxcontrib-autoprogram ~= 0.1.0
 autoapi >= 2.0.1
 sphinx_design ~= 0.6.1
-sphinx-copybutton >= 0.5
+sphinx-copybutton >= 0.5.0
 sphinx_autodoc_typehints ~= 3.5
-sphinx_reports ~= 0.9
+sphinx_reports ~= 0.9.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,18 +1,18 @@
 -r ../requirements.txt
 
 # Enforce latest version on ReadTheDocs
-sphinx ~= 8.2
-docutils ~= 0.21.0
+sphinx ~= 9.1
+docutils ~= 0.22.0
 docutils_stubs ~= 0.0.22
 
 # ReadTheDocs Theme
-sphinx_rtd_theme ~= 3.0
+sphinx_rtd_theme ~= 3.1
 
 # Sphinx Extenstions
-sphinxcontrib-mermaid ~= 1.0
+sphinxcontrib-mermaid ~= 2.0
 sphinxcontrib-autoprogram ~= 0.1.0
 autoapi >= 2.0.1
-sphinx_design ~= 0.6.1
+sphinx_design ~= 0.7.0
 sphinx-copybutton >= 0.5.0
-sphinx_autodoc_typehints ~= 3.5
-sphinx_reports ~= 0.9.0
+sphinx_autodoc_typehints ~= 3.6
+sphinx_reports ~= 0.10.0

--- a/examples/Python/pytest/TestModuleA.py
+++ b/examples/Python/pytest/TestModuleA.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 class A:
 	_value: int
 
-	def __init__(self, value: int = 0):
+	def __init__(self, value: int = 0) -> None:
 		self._value = value
 
 	@property
@@ -17,24 +17,24 @@ class A:
 
 
 class Instantiation(TestCase):
-	def test_NoParameter(self):
+	def test_NoParameter(self) -> None:
 		a = A()
 
 		self.assertEqual(0, a.Value)
 
-	def test_Parameter(self):
+	def test_Parameter(self) -> None:
 		a = A(5)
 
 		self.assertEqual(5, a.Value)
 
 
 class Properties(TestCase):
-	def test_Getter(self):
+	def test_Getter(self) -> None:
 		a = A(10)
 
 		self.assertEqual(10, a.Value)
 
-	def test_Setter(self):
+	def test_Setter(self) -> None:
 		a = A(15)
 		self.assertEqual(15, a.Value)
 

--- a/examples/Python/pytest/TestModuleB.py
+++ b/examples/Python/pytest/TestModuleB.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 class C:
 	_value: int
 
-	def __init__(self, value: int = 0):
+	def __init__(self, value: int = 0) -> None:
 		self._value = value
 
 	def Add(self, value: int) -> int:
@@ -25,26 +25,26 @@ class C:
 
 
 class Instantiation(TestCase):
-	def test_NoParameter(self):
+	def test_NoParameter(self) -> None:
 		a = C()
 
 		self.assertEqual(0, a.Value)
 
-	def test_Parameter(self):
+	def test_Parameter(self) -> None:
 		a = C(5)
 
 		self.assertEqual(5, a.Value)
 
 
 class Operations(TestCase):
-	def test_Add(self):
+	def test_Add(self) -> None:
 		a = C(10)
 
 		self.assertEqual(10, a.Value)
 		self.assertEqual(15, a.Add(5))
 		self.assertEqual(15, a.Value)
 
-	def test_Sub(self):
+	def test_Sub(self) -> None:
 		a = C(10)
 
 		self.assertEqual(10, a.Value)

--- a/pyEDAA/Reports/CLI/__init__.py
+++ b/pyEDAA/Reports/CLI/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/pyEDAA/Reports/Dependency/__init__.py
+++ b/pyEDAA/Reports/Dependency/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/pyEDAA/Reports/DocumentationCoverage/Python.py
+++ b/pyEDAA/Reports/DocumentationCoverage/Python.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 # Copyright 2023-2023 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #

--- a/pyEDAA/Reports/DocumentationCoverage/__init__.py
+++ b/pyEDAA/Reports/DocumentationCoverage/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/pyEDAA/Reports/DocumentationCoverage/__init__.py
+++ b/pyEDAA/Reports/DocumentationCoverage/__init__.py
@@ -74,7 +74,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	_name:   str
 	_status: CoverageState
 
-	def __init__(self, name: str, parent: Nullable["Base"] = None):
+	def __init__(self, name: str, parent: Nullable["Base"] = None) -> None:
 		if name is None:
 			raise ValueError(f"Parameter 'name' must not be None.")
 

--- a/pyEDAA/Reports/Requirement/Python.py
+++ b/pyEDAA/Reports/Requirement/Python.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/pyEDAA/Reports/Requirement/__init__.py
+++ b/pyEDAA/Reports/Requirement/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/pyEDAA/Reports/Unittesting/JUnit/AntJUnit4.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/AntJUnit4.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 # Copyright 2023-2023 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #

--- a/pyEDAA/Reports/Unittesting/JUnit/AntJUnit4.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/AntJUnit4.py
@@ -81,7 +81,7 @@ class Testsuite(ju_Testsuite):
 		adhering to the Ant + JUnit4 dialect.
 
 		:param testsuite: Test suite from unified data model.
-		:return:          Test suite from JUnit specific data model (Ant + JUnit4 dialect).
+		:returns:         Test suite from JUnit specific data model (Ant + JUnit4 dialect).
 		"""
 		juTestsuite = cls(
 			testsuite._name,
@@ -131,7 +131,7 @@ class TestsuiteSummary(ju_TestsuiteSummary):
 		summary object adhering to the Ant + JUnit4 dialect.
 
 		:param testsuiteSummary: Test suite summary from unified data model.
-		:return:                 Test suite summary from JUnit specific data model (Ant + JUnit4 dialect).
+		:returns:                Test suite summary from JUnit specific data model (Ant + JUnit4 dialect).
 		"""
 		return cls(
 			testsuiteSummary._name,
@@ -325,7 +325,6 @@ class Document(ju_Document):
 
 		:param testcase:      The test case to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testcaseElement = SubElement(parentElement, "testcase")
 		if testcase.Classname is not None:

--- a/pyEDAA/Reports/Unittesting/JUnit/CTestJUnit.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/CTestJUnit.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 # Copyright 2023-2023 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #

--- a/pyEDAA/Reports/Unittesting/JUnit/CTestJUnit.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/CTestJUnit.py
@@ -82,7 +82,7 @@ class Testsuite(ju_Testsuite):
 		adhering to the CTest JUnit dialect.
 
 		:param testsuite: Test suite from unified data model.
-		:return:          Test suite from JUnit specific data model (CTest JUnit dialect).
+		:returns:         Test suite from JUnit specific data model (CTest JUnit dialect).
 		"""
 		juTestsuite = cls(
 			testsuite._name,
@@ -132,7 +132,7 @@ class TestsuiteSummary(ju_TestsuiteSummary):
 		summary object adhering to the CTest JUnit dialect.
 
 		:param testsuiteSummary: Test suite summary from unified data model.
-		:return:                 Test suite summary from JUnit specific data model (CTest JUnit dialect).
+		:returns:                Test suite summary from JUnit specific data model (CTest JUnit dialect).
 		"""
 		return cls(
 			testsuiteSummary._name,
@@ -326,7 +326,6 @@ class Document(ju_Document):
 
 		:param testcase:      The test case to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testcaseElement = SubElement(parentElement, "testcase")
 		if testcase.Classname is not None:

--- a/pyEDAA/Reports/Unittesting/JUnit/GoogleTestJUnit.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/GoogleTestJUnit.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 # Copyright 2023-2023 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #

--- a/pyEDAA/Reports/Unittesting/JUnit/GoogleTestJUnit.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/GoogleTestJUnit.py
@@ -81,7 +81,7 @@ class Testsuite(ju_Testsuite):
 		adhering to the GoogleTest JUnit dialect.
 
 		:param testsuite: Test suite from unified data model.
-		:return:          Test suite from JUnit specific data model (GoogleTest JUnit dialect).
+		:returns:         Test suite from JUnit specific data model (GoogleTest JUnit dialect).
 		"""
 		juTestsuite = cls(
 			testsuite._name,
@@ -131,7 +131,7 @@ class TestsuiteSummary(ju_TestsuiteSummary):
 		summary object adhering to the GoogleTest JUnit dialect.
 
 		:param testsuiteSummary: Test suite summary from unified data model.
-		:return:                 Test suite summary from JUnit specific data model (GoogleTest JUnit dialect).
+		:returns:                Test suite summary from JUnit specific data model (GoogleTest JUnit dialect).
 		"""
 		return cls(
 			testsuiteSummary._name,
@@ -316,7 +316,6 @@ class Document(ju_Document):
 
 		:param testsuite:     The test suite to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testsuiteElement = SubElement(parentElement, "testsuite")
 		testsuiteElement.attrib["name"] = testsuite._name
@@ -346,7 +345,6 @@ class Document(ju_Document):
 
 		:param testcase:      The test case to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testcaseElement = SubElement(parentElement, "testcase")
 		if testcase.Classname is not None:

--- a/pyEDAA/Reports/Unittesting/JUnit/PyTestJUnit.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/PyTestJUnit.py
@@ -81,7 +81,7 @@ class Testsuite(ju_Testsuite):
 		adhering to the pyTest JUnit dialect.
 
 		:param testsuite: Test suite from unified data model.
-		:return:          Test suite from JUnit specific data model (pyTest JUnitdialect).
+		:returns:         Test suite from JUnit specific data model (pyTest JUnitdialect).
 		"""
 		juTestsuite = cls(
 			testsuite._name,
@@ -131,7 +131,7 @@ class TestsuiteSummary(ju_TestsuiteSummary):
 		summary object adhering to the pyTest JUnit dialect.
 
 		:param testsuiteSummary: Test suite summary from unified data model.
-		:return:                 Test suite summary from JUnit specific data model (pyTest JUnit dialect).
+		:returns:                Test suite summary from JUnit specific data model (pyTest JUnit dialect).
 		"""
 		return cls(
 			testsuiteSummary._name,
@@ -315,7 +315,6 @@ class Document(ju_Document):
 
 		:param testsuite:     The test suite to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testsuiteElement = SubElement(parentElement, "testsuite")
 		testsuiteElement.attrib["name"] = testsuite._name
@@ -344,7 +343,6 @@ class Document(ju_Document):
 
 		:param testcase:      The test case to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testcaseElement = SubElement(parentElement, "testcase")
 		if testcase.Classname is not None:

--- a/pyEDAA/Reports/Unittesting/JUnit/PyTestJUnit.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/PyTestJUnit.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 # Copyright 2023-2023 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #

--- a/pyEDAA/Reports/Unittesting/JUnit/__init__.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/__init__.py
@@ -189,7 +189,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	_parent:         Nullable["Testsuite"]
 	_name:           str
 
-	def __init__(self, name: str, parent: Nullable["Testsuite"] = None):
+	def __init__(self, name: str, parent: Nullable["Testsuite"] = None) -> None:
 		"""
 		Initializes the fields of the base-class.
 
@@ -253,7 +253,7 @@ class BaseWithProperties(Base):
 		duration: Nullable[timedelta] = None,
 		assertionCount: Nullable[int] = None,
 		parent: Nullable["Testsuite"] = None
-	):
+	) -> None:
 		"""
 		Initializes the fields of the base-class.
 
@@ -395,7 +395,7 @@ class Testcase(BaseWithProperties):
 		status: TestcaseStatus = TestcaseStatus.Unknown,
 		assertionCount: Nullable[int] = None,
 		parent: Nullable["Testclass"] = None
-	):
+	) -> None:
 		"""
 		Initializes the fields of a test case.
 
@@ -555,7 +555,7 @@ class TestsuiteBase(BaseWithProperties):
 		duration:  Nullable[timedelta] = None,
 		status: TestsuiteStatus = TestsuiteStatus.Unknown,
 		parent: Nullable["Testsuite"] = None
-	):
+	) -> None:
 		"""
 		Initializes the based-class fields of a test suite or test summary.
 
@@ -657,7 +657,7 @@ class Testclass(Base):
 		classname: str,
 		testcases: Nullable[Iterable["Testcase"]] = None,
 		parent: Nullable["Testsuite"] = None
-	):
+	) -> None:
 		"""
 		Initializes the fields of the test class.
 
@@ -781,7 +781,7 @@ class Testsuite(TestsuiteBase):
 		status: TestsuiteStatus = TestsuiteStatus.Unknown,
 		testclasses: Nullable[Iterable["Testclass"]] = None,
 		parent: Nullable["TestsuiteSummary"] = None
-	):
+	) -> None:
 		"""
 		Initializes the fields of a test suite.
 
@@ -1045,7 +1045,7 @@ class TestsuiteSummary(TestsuiteBase):
 		duration:  Nullable[timedelta] = None,
 		status: TestsuiteStatus = TestsuiteStatus.Unknown,
 		testsuites: Nullable[Iterable[Testsuite]] = None
-	):
+	) -> None:
 		super().__init__(name, startTime, duration, status, None)
 
 		self._testsuites = {}

--- a/pyEDAA/Reports/Unittesting/JUnit/__init__.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 # Copyright 2023-2023 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #

--- a/pyEDAA/Reports/Unittesting/JUnit/__init__.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/__init__.py
@@ -195,9 +195,9 @@ class Base(metaclass=ExtendedType, slots=True):
 
 		:param name:        Name of the test entity.
 		:param parent:      Reference to the parent test entity.
-		:raises ValueError: If parameter 'name' is None.
-		:raises TypeError:  If parameter 'name' is not a string.
-		:raises ValueError: If parameter 'name' is empty.
+		:raises ValueError: When parameter 'name' is None.
+		:raises TypeError:  When parameter 'name' is not a string.
+		:raises ValueError: When parameter 'name' is empty.
 		"""
 		if name is None:
 			raise ValueError(f"Parameter 'name' is None.")
@@ -217,7 +217,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the reference to the parent test entity.
 
-		:return: Reference to the parent entity.
+		:returns: Reference to the parent entity.
 		"""
 		return self._parent
 
@@ -228,7 +228,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the test entity's name.
 
-		:return:
+		:returns: Name of the test entity.
 		"""
 		return self._name
 
@@ -292,7 +292,7 @@ class BaseWithProperties(Base):
 
 		   The JUnit format doesn't distinguish setup, run and teardown durations.
 
-		:return: Duration of the entity's execution.
+		:returns: Duration of the entity's execution.
 		"""
 		return self._duration
 
@@ -306,7 +306,7 @@ class BaseWithProperties(Base):
 
 		   The JUnit format doesn't distinguish passed and failed assertions.
 
-		:return: Number of assertions.
+		:returns: Number of assertions.
 		"""
 
 	def __len__(self) -> int:
@@ -315,7 +315,7 @@ class BaseWithProperties(Base):
 
 		Syntax: :pycode:`length = len(obj)`
 
-		:return: Number of annotated properties.
+		:returns: Number of annotated properties.
 		"""
 		return len(self._properties)
 
@@ -326,7 +326,7 @@ class BaseWithProperties(Base):
 		Syntax: :pycode:`value = obj[name]`
 
 		:param name: Name if the property.
-		:return:     Value of the accessed property.
+		:returns:    Value of the accessed property.
 		"""
 		return self._properties[name]
 
@@ -360,7 +360,7 @@ class BaseWithProperties(Base):
 		Syntax: :pycode:`name in obj`
 
 		:param name: Name of the property.
-		:return:     True, if the property was annotated.
+		:returns:    True, if the property was annotated.
 		"""
 		return name in self._properties
 
@@ -370,7 +370,7 @@ class BaseWithProperties(Base):
 
 		Syntax: :pycode:`for name, value in obj:`
 
-		:return: A generator of property tuples (name, value).
+		:returns: A generator of property tuples (name, value).
 		"""
 		yield from self._properties.items()
 
@@ -431,7 +431,7 @@ class Testcase(BaseWithProperties):
 		"""
 		Read-only property returning the class name of the test case.
 
-		:return: The test case's class name.
+		:returns: The test case's class name.
 
 		.. note::
 
@@ -448,7 +448,7 @@ class Testcase(BaseWithProperties):
 		"""
 		Read-only property returning the status of the test case.
 
-		:return: The test case's status.
+		:returns: The test case's status.
 		"""
 		return self._status
 
@@ -461,7 +461,7 @@ class Testcase(BaseWithProperties):
 
 		   The JUnit format doesn't distinguish passed and failed assertions.
 
-		:return: Number of assertions.
+		:returns: Number of assertions.
 		"""
 		if self._assertionCount is None:
 			return 0
@@ -493,7 +493,7 @@ class Testcase(BaseWithProperties):
 		Convert a test case of the unified test entity data model to the JUnit specific data model's test case object.
 
 		:param testcase: Test case from unified data model.
-		:return:         Test case from JUnit specific data model.
+		:returns:        Test case from JUnit specific data model.
 		"""
 		return cls(
 			testcase._name,
@@ -695,7 +695,7 @@ class Testclass(Base):
 		"""
 		Read-only property returning the name of the test class.
 
-		:return: The test class' name.
+		:returns: The test class' name.
 		"""
 		return self._name
 
@@ -704,7 +704,7 @@ class Testclass(Base):
 		"""
 		Read-only property returning a reference to the internal dictionary of test cases.
 
-		:return: Reference to the dictionary of test cases.
+		:returns: Reference to the dictionary of test cases.
 		"""
 		return self._testcases
 
@@ -713,7 +713,7 @@ class Testclass(Base):
 		"""
 		Read-only property returning the number of all test cases in the test entity hierarchy.
 
-		:return: Number of test cases.
+		:returns: Number of test cases.
 		"""
 		return len(self._testcases)
 
@@ -955,7 +955,7 @@ class Testsuite(TestsuiteBase):
 		Convert a test suite of the unified test entity data model to the JUnit specific data model's test suite object.
 
 		:param testsuite: Test suite from unified data model.
-		:return:          Test suite from JUnit specific data model.
+		:returns:         Test suite from JUnit specific data model.
 		"""
 		juTestsuite = cls(
 			testsuite._name,
@@ -1149,7 +1149,7 @@ class TestsuiteSummary(TestsuiteBase):
 		Convert a test suite summary of the unified test entity data model to the JUnit specific data model's test suite.
 
 		:param testsuiteSummary: Test suite summary from unified data model.
-		:return:                 Test suite summary from JUnit specific data model.
+		:returns:                Test suite summary from JUnit specific data model.
 		"""
 		return cls(
 			testsuiteSummary._name,
@@ -1165,7 +1165,7 @@ class TestsuiteSummary(TestsuiteBase):
 
 		All fields are copied to the new instance. Child elements like test suites are copied recursively.
 
-		:return: A test suite summary of the unified test entity data model.
+		:returns: A test suite summary of the unified test entity data model.
 		"""
 		return ut_TestsuiteSummary(
 			self._name,
@@ -1202,7 +1202,7 @@ class Document(TestsuiteSummary, ut_Document):
 	_readerMode:        JUnitReaderMode
 	_xmlDocument:       Nullable[_ElementTree]
 
-	def __init__(self, xmlReportFile: Path, analyzeAndConvert: bool = False, readerMode: JUnitReaderMode = JUnitReaderMode.Default):
+	def __init__(self, xmlReportFile: Path, analyzeAndConvert: bool = False, readerMode: JUnitReaderMode = JUnitReaderMode.Default) -> None:
 		super().__init__("Unprocessed JUnit XML file")
 
 		self._readerMode = readerMode
@@ -1358,7 +1358,7 @@ class Document(TestsuiteSummary, ut_Document):
 		:param element:            The XML element node with a ``name`` attribute.
 		:param default:            The default value, if no ``name`` attribute was found.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``name`` attribute's content if found, otherwise the given default value.
+		:returns:                  The ``name`` attribute's content if found, otherwise the given default value.
 		:raises UnittestException: If optional is false and no ``name`` attribute exists on the given element node.
 		"""
 		if "name" in element.attrib:
@@ -1374,7 +1374,7 @@ class Document(TestsuiteSummary, ut_Document):
 
 		:param element:            The XML element node with a ``timestamp`` attribute.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``timestamp`` attribute's content if found, otherwise ``None``.
+		:returns:                  The ``timestamp`` attribute's content if found, otherwise ``None``.
 		:raises UnittestException: If optional is false and no ``timestamp`` attribute exists on the given element node.
 		"""
 		if "timestamp" in element.attrib:
@@ -1391,7 +1391,7 @@ class Document(TestsuiteSummary, ut_Document):
 
 		:param element:            The XML element node with a ``time`` attribute.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``time`` attribute's content if found, otherwise ``None``.
+		:returns:                  The ``time`` attribute's content if found, otherwise ``None``.
 		:raises UnittestException: If optional is false and no ``time`` attribute exists on the given element node.
 		"""
 		if "time" in element.attrib:
@@ -1409,7 +1409,7 @@ class Document(TestsuiteSummary, ut_Document):
 		:param element:            The XML element node with a ``hostname`` attribute.
 		:param default:            The default value, if no ``hostname`` attribute was found.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``hostname`` attribute's content if found, otherwise the given default value.
+		:returns:                  The ``hostname`` attribute's content if found, otherwise the given default value.
 		:raises UnittestException: If optional is false and no ``hostname`` attribute exists on the given element node.
 		"""
 		if "hostname" in element.attrib:
@@ -1424,7 +1424,7 @@ class Document(TestsuiteSummary, ut_Document):
 		Convert the ``classname`` attribute from an XML element node to a string.
 
 		:param element:            The XML element node with a ``classname`` attribute.
-		:return:                   The ``classname`` attribute's content.
+		:returns:                  The ``classname`` attribute's content.
 		:raises UnittestException: If no ``classname`` attribute exists on the given element node.
 		"""
 		if "classname" in element.attrib:
@@ -1439,7 +1439,7 @@ class Document(TestsuiteSummary, ut_Document):
 		:param element:            The XML element node with a ``tests`` attribute.
 		:param default:            The default value, if no ``tests`` attribute was found.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``tests`` attribute's content if found, otherwise the given default value.
+		:returns:                  The ``tests`` attribute's content if found, otherwise the given default value.
 		:raises UnittestException: If optional is false and no ``tests`` attribute exists on the given element node.
 		"""
 		if "tests" in element.attrib:
@@ -1456,7 +1456,7 @@ class Document(TestsuiteSummary, ut_Document):
 		:param element:            The XML element node with a ``skipped`` attribute.
 		:param default:            The default value, if no ``skipped`` attribute was found.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``skipped`` attribute's content if found, otherwise the given default value.
+		:returns:                  The ``skipped`` attribute's content if found, otherwise the given default value.
 		:raises UnittestException: If optional is false and no ``skipped`` attribute exists on the given element node.
 		"""
 		if "skipped" in element.attrib:
@@ -1473,7 +1473,7 @@ class Document(TestsuiteSummary, ut_Document):
 		:param element:            The XML element node with a ``errors`` attribute.
 		:param default:            The default value, if no ``errors`` attribute was found.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``errors`` attribute's content if found, otherwise the given default value.
+		:returns:                  The ``errors`` attribute's content if found, otherwise the given default value.
 		:raises UnittestException: If optional is false and no ``errors`` attribute exists on the given element node.
 		"""
 		if "errors" in element.attrib:
@@ -1490,7 +1490,7 @@ class Document(TestsuiteSummary, ut_Document):
 		:param element:            The XML element node with a ``failures`` attribute.
 		:param default:            The default value, if no ``failures`` attribute was found.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``failures`` attribute's content if found, otherwise the given default value.
+		:returns:                  The ``failures`` attribute's content if found, otherwise the given default value.
 		:raises UnittestException: If optional is false and no ``failures`` attribute exists on the given element node.
 		"""
 		if "failures" in element.attrib:
@@ -1507,7 +1507,7 @@ class Document(TestsuiteSummary, ut_Document):
 		:param element:            The XML element node with a ``assertions`` attribute.
 		:param default:            The default value, if no ``assertions`` attribute was found.
 		:param optional:           If false, an exception is raised for the missing attribute.
-		:return:                   The ``assertions`` attribute's content if found, otherwise the given default value.
+		:returns:                  The ``assertions`` attribute's content if found, otherwise the given default value.
 		:raises UnittestException: If optional is false and no ``assertions`` attribute exists on the given element node.
 		"""
 		if "assertions" in element.attrib:
@@ -1641,7 +1641,6 @@ class Document(TestsuiteSummary, ut_Document):
 
 		:param testsuite:     The test suite to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testsuiteElement = SubElement(parentElement, "testsuite")
 		testsuiteElement.attrib["name"] = testsuite._name
@@ -1670,7 +1669,6 @@ class Document(TestsuiteSummary, ut_Document):
 
 		:param testcase:      The test case to convert to an XML data structures.
 		:param parentElement: The parent XML data structure element, this data structure part will be added to.
-		:return:
 		"""
 		testcaseElement = SubElement(parentElement, "testcase")
 		if testcase.Classname is not None:

--- a/pyEDAA/Reports/Unittesting/__init__.py
+++ b/pyEDAA/Reports/Unittesting/__init__.py
@@ -305,7 +305,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		expectedFatalCount: int = 0,
 		keyValuePairs: Nullable[Mapping[str, Any]] = None,
 		parent: Nullable["TestsuiteBase"] = None
-	):
+	) -> None:
 		"""
 		Initializes the fields of the base-class.
 
@@ -651,7 +651,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		yield from self._dict.items()
 
 	@abstractmethod
-	def Aggregate(self, strict: bool = True):
+	def Aggregate(self, strict: bool = True) -> None:
 		"""
 		Aggregate all test entities in the hierarchy.
 
@@ -703,7 +703,7 @@ class Testcase(Base):
 		expectedFatalCount: int = 0,
 		keyValuePairs: Nullable[Mapping[str, Any]] = None,
 		parent: Nullable["Testsuite"] = None
-	):
+	) -> None:
 		"""
 		Initializes the fields of a test case.
 
@@ -943,7 +943,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		testsuites: Nullable[Iterable[TestsuiteType]] = None,
 		keyValuePairs: Nullable[Mapping[str, Any]] = None,
 		parent: Nullable["Testsuite"] = None
-	):
+	) -> None:
 		"""
 		Initializes the based-class fields of a test suite or test summary.
 
@@ -1338,7 +1338,7 @@ class Testsuite(TestsuiteBase[TestsuiteType]):
 		testcases: Nullable[Iterable["Testcase"]] = None,
 		keyValuePairs: Nullable[Mapping[str, Any]] = None,
 		parent: Nullable[TestsuiteType] = None
-	):
+	) -> None:
 		"""
 		Initializes the fields of a test suite.
 
@@ -1708,7 +1708,7 @@ class Document(metaclass=ExtendedType, mixin=True):
 	_analysisDuration: float  #: TODO: replace by Timer; should be timedelta?
 	_modelConversion:  float  #: TODO: replace by Timer; should be timedelta?
 
-	def __init__(self, reportFile: Path, analyzeAndConvert: bool = False):
+	def __init__(self, reportFile: Path, analyzeAndConvert: bool = False) -> None:
 		self._path = reportFile
 
 		self._analysisDuration = -1.0
@@ -1774,7 +1774,7 @@ class Merged(metaclass=ExtendedType, mixin=True):
 
 	_mergedCount: int
 
-	def __init__(self, mergedCount: int = 1):
+	def __init__(self, mergedCount: int = 1) -> None:
 		self._mergedCount = mergedCount
 
 	@readonly
@@ -1786,7 +1786,7 @@ class Merged(metaclass=ExtendedType, mixin=True):
 class Combined(metaclass=ExtendedType, mixin=True):
 	_combinedCount: int
 
-	def __init__(self, combinedCound: int = 1):
+	def __init__(self, combinedCound: int = 1) -> None:
 		self._combinedCount = combinedCound
 
 	@readonly
@@ -1802,7 +1802,7 @@ class MergedTestcase(Testcase, Merged):
 		self,
 		testcase: Testcase,
 		parent: Nullable["Testsuite"] = None
-	):
+	) -> None:
 		if testcase is None:
 			raise ValueError(f"Parameter 'testcase' is None.")
 
@@ -1897,7 +1897,7 @@ class MergedTestsuite(Testsuite, Merged):
 		addTestsuites: bool = False,
 		addTestcases: bool = False,
 		parent: Nullable["Testsuite"] = None
-	):
+	) -> None:
 		if testsuite is None:
 			raise ValueError(f"Parameter 'testsuite' is None.")
 

--- a/pyEDAA/Reports/Unittesting/__init__.py
+++ b/pyEDAA/Reports/Unittesting/__init__.py
@@ -320,22 +320,22 @@ class Base(metaclass=ExtendedType, slots=True):
 		:param fatalCount:         Count of encountered fatal errors.
 		:param keyValuePairs:      Mapping of key-value pairs to initialize the test entity with.
 		:param parent:             Reference to the parent test entity.
-		:raises TypeError:         If parameter 'parent' is not a TestsuiteBase.
-		:raises ValueError:        If parameter 'name' is None.
-		:raises TypeError:         If parameter 'name' is not a string.
-		:raises ValueError:        If parameter 'name' is empty.
-		:raises TypeError:         If parameter 'testDuration' is not a timedelta.
-		:raises TypeError:         If parameter 'setupDuration' is not a timedelta.
-		:raises TypeError:         If parameter 'teardownDuration' is not a timedelta.
-		:raises TypeError:         If parameter 'totalDuration' is not a timedelta.
-		:raises TypeError:         If parameter 'warningCount' is not an integer.
-		:raises TypeError:         If parameter 'errorCount' is not an integer.
-		:raises TypeError:         If parameter 'fatalCount' is not an integer.
-		:raises TypeError:         If parameter 'expectedWarningCount' is not an integer.
-		:raises TypeError:         If parameter 'expectedErrorCount' is not an integer.
-		:raises TypeError:         If parameter 'expectedFatalCount' is not an integer.
-		:raises TypeError:         If parameter 'keyValuePairs' is not a Mapping.
-		:raises ValueError:        If parameter 'totalDuration' is not consistent.
+		:raises TypeError:         When parameter 'parent' is not a TestsuiteBase.
+		:raises ValueError:        When parameter 'name' is None.
+		:raises TypeError:         When parameter 'name' is not a string.
+		:raises ValueError:        When parameter 'name' is empty.
+		:raises TypeError:         When parameter 'testDuration' is not a timedelta.
+		:raises TypeError:         When parameter 'setupDuration' is not a timedelta.
+		:raises TypeError:         When parameter 'teardownDuration' is not a timedelta.
+		:raises TypeError:         When parameter 'totalDuration' is not a timedelta.
+		:raises TypeError:         When parameter 'warningCount' is not an integer.
+		:raises TypeError:         When parameter 'errorCount' is not an integer.
+		:raises TypeError:         When parameter 'fatalCount' is not an integer.
+		:raises TypeError:         When parameter 'expectedWarningCount' is not an integer.
+		:raises TypeError:         When parameter 'expectedErrorCount' is not an integer.
+		:raises TypeError:         When parameter 'expectedFatalCount' is not an integer.
+		:raises TypeError:         When parameter 'keyValuePairs' is not a Mapping.
+		:raises ValueError:        When parameter 'totalDuration' is not consistent.
 		"""
 
 		if parent is not None and not isinstance(parent, TestsuiteBase):
@@ -480,7 +480,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the reference to the parent test entity.
 
-		:return: Reference to the parent entity.
+		:returns: Reference to the parent entity.
 		"""
 		return self._parent
 
@@ -489,7 +489,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the test entity's name.
 
-		:return:
+		:returns: The test entities name.
 		"""
 		return self._name
 
@@ -498,7 +498,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the time when the test entity was started.
 
-		:return: Time when the test entity was started.
+		:returns: Time when the test entity was started.
 		"""
 		return self._startTime
 
@@ -507,7 +507,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the duration of the test entity's setup.
 
-		:return: Duration it took to set up the entity.
+		:returns: Duration it took to set up the entity.
 		"""
 		return self._setupDuration
 
@@ -519,7 +519,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		This duration is excluding setup and teardown durations. In case setup and/or teardown durations are unknown or not
 		distinguishable, assign setup and teardown durations with zero.
 
-		:return: Duration of the entity's test run.
+		:returns: Duration of the entity's test run.
 		"""
 		return self._testDuration
 
@@ -528,7 +528,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the duration of the test entity's teardown.
 
-		:return: Duration it took to tear down the entity.
+		:returns: Duration it took to tear down the entity.
 		"""
 		return self._teardownDuration
 
@@ -539,7 +539,7 @@ class Base(metaclass=ExtendedType, slots=True):
 
 		this duration includes setup and teardown durations.
 
-		:return: Total duration of the entity's execution (setup + test + teardown)
+		:returns: Total duration of the entity's execution (setup + test + teardown)
 		"""
 		return self._totalDuration
 
@@ -548,7 +548,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the number of encountered warnings.
 
-		:return: Count of encountered warnings.
+		:returns: Count of encountered warnings.
 		"""
 		return self._warningCount
 
@@ -557,7 +557,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the number of encountered errors.
 
-		:return: Count of encountered errors.
+		:returns: Count of encountered errors.
 		"""
 		return self._errorCount
 
@@ -566,7 +566,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the number of encountered fatal errors.
 
-		:return: Count of encountered fatal errors.
+		:returns: Count of encountered fatal errors.
 		"""
 		return self._fatalCount
 
@@ -575,7 +575,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the number of expected warnings.
 
-		:return: Count of expected warnings.
+		:returns: Count of expected warnings.
 		"""
 		return self._expectedWarningCount
 
@@ -584,7 +584,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the number of expected errors.
 
-		:return: Count of expected errors.
+		:returns: Count of expected errors.
 		"""
 		return self._expectedErrorCount
 
@@ -593,7 +593,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property returning the number of expected fatal errors.
 
-		:return: Count of expected fatal errors.
+		:returns: Count of expected fatal errors.
 		"""
 		return self._expectedFatalCount
 
@@ -601,7 +601,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Returns the number of annotated key-value pairs.
 
-		:return: Number of annotated key-value pairs.
+		:returns: Number of annotated key-value pairs.
 		"""
 		return len(self._dict)
 
@@ -610,7 +610,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		Access a key-value pair by key.
 
 		:param key: Name if the key-value pair.
-		:return:    Value of the accessed key.
+		:returns:   Value of the accessed key.
 		"""
 		return self._dict[key]
 
@@ -638,7 +638,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		Returns True, if a key-value pairs was annotated by this key.
 
 		:param key: Name of the key-value pair.
-		:return:    True, if the pair was annotated.
+		:returns:   True, if the pair was annotated.
 		"""
 		return key in self._dict
 
@@ -646,7 +646,7 @@ class Base(metaclass=ExtendedType, slots=True):
 		"""
 		Iterate all annotated key-value pairs.
 
-		:return: A generator of key-value pair tuples (key, value).
+		:returns: A generator of key-value pair tuples (key, value).
 		"""
 		yield from self._dict.items()
 
@@ -654,8 +654,6 @@ class Base(metaclass=ExtendedType, slots=True):
 	def Aggregate(self, strict: bool = True) -> None:
 		"""
 		Aggregate all test entities in the hierarchy.
-
-		:return:
 		"""
 
 	@abstractmethod
@@ -807,7 +805,7 @@ class Testcase(Base):
 		"""
 		Read-only property returning the status of the test case.
 
-		:return: The test case's status.
+		:returns: The test case's status.
 		"""
 		return self._status
 
@@ -816,7 +814,7 @@ class Testcase(Base):
 		"""
 		Read-only property returning the number of assertions (checks) in a test case.
 
-		:return: Number of assertions.
+		:returns: Number of assertions.
 		"""
 		if self._assertionCount is None:
 			return 0
@@ -827,7 +825,7 @@ class Testcase(Base):
 		"""
 		Read-only property returning the number of failed assertions (failed checks) in a test case.
 
-		:return: Number of assertions.
+		:returns: Number of assertions.
 		"""
 		return self._failedAssertionCount
 
@@ -836,7 +834,7 @@ class Testcase(Base):
 		"""
 		Read-only property returning the number of passed assertions (successful checks) in a test case.
 
-		:return: Number of passed assertions.
+		:returns: Number of passed assertions.
 		"""
 		return self._passedAssertionCount
 
@@ -894,7 +892,7 @@ class Testcase(Base):
 
 		:pycode:`f"<Testcase {}: {} - assert/pass/fail:{}/{}/{} - warn/error/fatal:{}/{}/{} - setup/test/teardown:{}/{}/{}>"`
 
-		:return: Human-readable summary of a test case object.
+		:returns: Human-readable summary of a test case object.
 		"""
 		return (
 			f"<Testcase {self._name}: {self._status.name} -"
@@ -1039,7 +1037,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 
 		Test summaries always return kind ``Root``.
 
-		:return: Kind of the test suite.
+		:returns: Kind of the test suite.
 		"""
 		return self._kind
 
@@ -1048,7 +1046,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the aggregated overall status of the test suite.
 
-		:return: Overall status of the test suite.
+		:returns: Overall status of the test suite.
 		"""
 		return self._status
 
@@ -1057,7 +1055,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning a reference to the internal dictionary of test suites.
 
-		:return: Reference to the dictionary of test suite.
+		:returns: Reference to the dictionary of test suite.
 		"""
 		return self._testsuites
 
@@ -1066,7 +1064,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of all test suites in the test suite hierarchy.
 
-		:return: Number of test suites.
+		:returns: Number of test suites.
 		"""
 		return 1 + sum(testsuite.TestsuiteCount for testsuite in self._testsuites.values())
 
@@ -1075,7 +1073,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of all test cases in the test entity hierarchy.
 
-		:return: Number of test cases.
+		:returns: Number of test cases.
 		"""
 		return sum(testsuite.TestcaseCount for testsuite in self._testsuites.values())
 
@@ -1084,7 +1082,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of all assertions in all test cases in the test entity hierarchy.
 
-		:return: Number of assertions in all test cases.
+		:returns: Number of assertions in all test cases.
 		"""
 		return sum(ts.AssertionCount for ts in self._testsuites.values())
 
@@ -1093,7 +1091,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of all failed assertions in all test cases in the test entity hierarchy.
 
-		:return: Number of failed assertions in all test cases.
+		:returns: Number of failed assertions in all test cases.
 		"""
 		raise NotImplementedError()
 		# return self._assertionCount - (self._warningCount + self._errorCount + self._fatalCount)
@@ -1103,7 +1101,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of all passed assertions in all test cases in the test entity hierarchy.
 
-		:return: Number of passed assertions in all test cases.
+		:returns: Number of passed assertions in all test cases.
 		"""
 		raise NotImplementedError()
 		# return self._assertionCount - (self._warningCount + self._errorCount + self._fatalCount)
@@ -1117,7 +1115,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of inconsistent tests in the test suite hierarchy.
 
-		:return: Number of inconsistent tests.
+		:returns: Number of inconsistent tests.
 		"""
 		return self._inconsistent
 
@@ -1126,7 +1124,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of excluded tests in the test suite hierarchy.
 
-		:return: Number of excluded tests.
+		:returns: Number of excluded tests.
 		"""
 		return self._excluded
 
@@ -1135,7 +1133,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of skipped tests in the test suite hierarchy.
 
-		:return: Number of skipped tests.
+		:returns: Number of skipped tests.
 		"""
 		return self._skipped
 
@@ -1144,7 +1142,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of tests with errors in the test suite hierarchy.
 
-		:return: Number of errored tests.
+		:returns: Number of errored tests.
 		"""
 		return self._errored
 
@@ -1153,7 +1151,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of weak tests in the test suite hierarchy.
 
-		:return: Number of weak tests.
+		:returns: Number of weak tests.
 		"""
 		return self._weak
 
@@ -1162,7 +1160,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of failed tests in the test suite hierarchy.
 
-		:return: Number of failed tests.
+		:returns: Number of failed tests.
 		"""
 		return self._failed
 
@@ -1171,7 +1169,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 		"""
 		Read-only property returning the number of passed tests in the test suite hierarchy.
 
-		:return: Number of passed tests.
+		:returns: Number of passed tests.
 		"""
 		return self._passed
 
@@ -1410,7 +1408,7 @@ class Testsuite(TestsuiteBase[TestsuiteType]):
 		"""
 		Read-only property returning a reference to the internal dictionary of test cases.
 
-		:return: Reference to the dictionary of test cases.
+		:returns: Reference to the dictionary of test cases.
 		"""
 		return self._testcases
 
@@ -1419,7 +1417,7 @@ class Testsuite(TestsuiteBase[TestsuiteType]):
 		"""
 		Read-only property returning the number of all test cases in the test entity hierarchy.
 
-		:return: Number of test cases.
+		:returns: Number of test cases.
 		"""
 		return super().TestcaseCount + len(self._testcases)
 
@@ -1737,7 +1735,7 @@ class Document(metaclass=ExtendedType, mixin=True):
 		   This includes usually the duration to validate and parse the file format, but it excludes the time to convert the
 		   content to the test entity hierarchy.
 
-		:return: Duration to analyze the document.
+		:returns: Duration to analyze the document.
 		"""
 		return timedelta(seconds=self._analysisDuration)
 
@@ -1751,7 +1749,7 @@ class Document(metaclass=ExtendedType, mixin=True):
 		   This includes usually the duration to convert the document's content to the test entity hierarchy. It might also
 		   include the duration to (re-)aggregate all states and statistics in the hierarchy.
 
-		:return: Duration to convert the document.
+		:returns: Duration to convert the document.
 		"""
 		return timedelta(seconds=self._modelConversion)
 

--- a/pyEDAA/Reports/Unittesting/__init__.py
+++ b/pyEDAA/Reports/Unittesting/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/pyEDAA/Reports/__init__.py
+++ b/pyEDAA/Reports/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #
@@ -33,7 +33,7 @@ Various report abstract data models and report format converters.
 """
 __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
-__copyright__ = "2021-2025, Electronic Design Automation Abstraction (EDA²)"
+__copyright__ = "2021-2026, Electronic Design Automation Abstraction (EDA²)"
 __license__ =   "Apache License, Version 2.0"
 __version__ =   "0.17.2"
 __keywords__ =  ["Reports", "Abstract Model", "Data Model", "Unit Testing", "Testcase", "Testsuite", "OSVVM", "YAML", "XML"]

--- a/pyEDAA/Reports/__init__.py
+++ b/pyEDAA/Reports/__init__.py
@@ -35,7 +35,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2021-2026, Electronic Design Automation Abstraction (EDA²)"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "0.17.2"
+__version__ =   "0.17.3"
 __keywords__ =  ["Reports", "Abstract Model", "Data Model", "Unit Testing", "Testcase", "Testsuite", "OSVVM", "YAML", "XML"]
 
 from enum                 import Enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools >= 80.0",
   "wheel ~= 0.45",
-  "pyTooling ~= 8.7"
+  "pyTooling ~= 8.8"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
   "setuptools >= 80.0",
-  "wheel ~= 0.45",
-  "pyTooling ~= 8.8"
+  "wheel ~= 0.45.0",
+  "pyTooling ~= 8.10"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,22 +36,20 @@ namespace_packages = true
 html_report = "report/typing"
 
 [tool.pytest]
-junit_xml = "report/unit/UnittestReportSummary.xml"
-
-[tool.pyedaa-reports]
-junit_xml = "report/unit/unittest.xml"
-
-[tool.pytest.ini_options]
-addopts = "--tb=native"
+addopts = ["--tb=native"]
 # Don't set 'python_classes = *' otherwise, pytest doesn't search for classes
 # derived from unittest.Testcase
-python_files = "*"
-python_functions = "test_*"
+python_files = ["*"]
+python_functions = ["test_*"]
 filterwarnings = [
 	"error::DeprecationWarning",
 	"error::PendingDeprecationWarning"
 ]
+junit_xml = "report/unit/UnittestReportSummary.xml"
 junit_logging = "all"
+
+[tool.pyedaa-reports]
+junit_xml = "report/unit/unittest.xml"
 
 [tool.interrogate]
 color = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools >= 80.0",
   "wheel ~= 0.45.0",
-  "pyTooling ~= 8.10"
+  "pyTooling ~= 8.11"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
   "setuptools >= 80.0",
-  "wheel ~= 0.45.0",
-  "pyTooling ~= 8.11"
+  "pyTooling ~= 8.12"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -26,7 +25,7 @@ variable-naming-style = "camelCase"
 
 [tool.mypy]
 packages = ["pyEDAA.Reports"]
-python_version = "3.13"
+python_version = "3.14"
 #ignore_missing_imports = true
 strict = true
 pretty = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyTooling >= 8.7, <10.0
+pyTooling >= 8.8, <10.0
 ruamel.yaml ~= 0.18
 lxml >= 5.4, <7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyTooling >= 8.8, <10.0
-ruamel.yaml ~= 0.18
+pyTooling >= 8.10, <10.0
+ruamel.yaml ~= 0.18.0
 lxml >= 5.4, <7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyTooling >= 8.10, <10.0
-ruamel.yaml ~= 0.18.0
+pyTooling >= 8.11, <10.0
+ruamel.yaml ~= 0.19.0
 lxml >= 5.4, <7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyTooling >= 8.11, <10.0
+pyTooling[terminal] >= 8.12, <10.0
 ruamel.yaml ~= 0.19.0
 lxml >= 5.4, <7.0

--- a/run.ps1
+++ b/run.ps1
@@ -117,7 +117,9 @@ $jobs = @()
 if ($livedoc)
 { Write-Host -ForegroundColor DarkYellow    "[live][DOC]       Building documentation using Sphinx ..."
 
-  .\doc\make.bat html --verbose
+  cd doc
+  py -3.14 -m sphinx.cmd.build -b html . _build/html --doctree-dir _build/doctrees --jobs auto --warning-file _build/sphinx-warnings.log --verbose
+  cd ..
 
   Write-Host -ForegroundColor DarkYellow    "[live][DOC]       Documentation finished"
 }
@@ -127,7 +129,8 @@ elseif ($doc)
 
   # Compile documentation
   $compileDocFunc = {
-    .\doc\make.bat html --verbose
+    cd doc
+    py -3.14 -m sphinx.cmd.build -b html . _build/html --doctree-dir _build/doctrees --jobs auto --warning-file _build/sphinx-warnings.log --verbose
   }
   $docJob = Start-Job -Name "Documentation" -ScriptBlock $compileDocFunc
 #  $jobs += $docJob

--- a/run.ps1
+++ b/run.ps1
@@ -33,7 +33,7 @@ Param(
 )
 
 $PackageName = "pyEDAA.Reports"
-$PackageVersion = "0.17.2"
+$PackageVersion = "0.17.3"
 
 # set default values
 $EnableDebug =        [bool]$PSCmdlet.MyInvocation.BoundParameters["Debug"]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/app/GitHub/Examples.py
+++ b/tests/app/GitHub/Examples.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/app/GitHub/Examples.py
+++ b/tests/app/GitHub/Examples.py
@@ -48,7 +48,7 @@ if __name__ == "__main__": # pragma: no cover
 
 
 class CppGoogleTest(TestCase):
-	def test_gtest(self):
+	def test_gtest(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/gtest.xml")
@@ -65,7 +65,7 @@ class CppGoogleTest(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/gtest.xml")
@@ -111,7 +111,7 @@ class CppGoogleTest(TestCase):
 
 
 class CppGoogleTestCTest(TestCase):
-	def test_ctest(self):
+	def test_ctest(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/ctest.xml")
@@ -128,7 +128,7 @@ class CppGoogleTestCTest(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/ctest.xml")
@@ -174,7 +174,7 @@ class CppGoogleTestCTest(TestCase):
 
 
 class JavaAntJUnit4(TestCase):
-	def test_JUnit4(self):
+	def test_JUnit4(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Java-Ant-JUnit4/TEST-my.AllTests.xml")
@@ -191,7 +191,7 @@ class JavaAntJUnit4(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Java-Ant-JUnit4/TEST-my.AllTests.xml")
@@ -237,7 +237,7 @@ class JavaAntJUnit4(TestCase):
 
 
 class PythonPyTest(TestCase):
-	def test_Read(self):
+	def test_Read(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Python-pytest/TestReportSummary.xml")
@@ -259,7 +259,7 @@ class PythonPyTest(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Python-pytest/TestReportSummary.xml")

--- a/tests/app/GitHub/__init__.py
+++ b/tests/app/GitHub/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/app/requirements.txt
+++ b/tests/app/requirements.txt
@@ -1,1 +1,5 @@
--r ../requirements.txt
+-r ../../requirements.txt
+
+# Test Runner
+pytest ~= 9.0
+pytest-cov ~= 7.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,7 @@
 Coverage ~= 7.11
 
 # Test Runner
-pytest ~= 8.4
+pytest ~= 9.0
 pytest-cov ~= 7.0
 
 # Static Type Checking

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,2 @@
--r ../requirements.txt
-
-# Coverage collection
-Coverage ~= 7.13
-
-# Test Runner
-pytest ~= 9.0
-pytest-cov ~= 7.0
-
-# Static Type Checking
-mypy[reports] ~= 1.19
-typing_extensions ~= 4.15
-lxml >= 5.4, <7.0
+-r unit/requirements.txt
+-r typing/requirements.txt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,13 @@
 -r ../requirements.txt
 
 # Coverage collection
-Coverage ~= 7.11
+Coverage ~= 7.13
 
 # Test Runner
 pytest ~= 9.0
 pytest-cov ~= 7.0
 
 # Static Type Checking
-mypy[reports] ~= 1.18
+mypy[reports] ~= 1.19
 typing_extensions ~= 4.15
 lxml >= 5.4, <7.0

--- a/tests/typing/requirements.txt
+++ b/tests/typing/requirements.txt
@@ -1,0 +1,6 @@
+-r ../../requirements.txt
+
+# Static Type Checking
+mypy[reports] ~= 1.19
+typing_extensions ~= 4.15
+lxml >= 5.4, <7.0

--- a/tests/unit/DocumentationCoverage/DataModel.py
+++ b/tests/unit/DocumentationCoverage/DataModel.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/DocumentationCoverage/DocStrCoverage.py
+++ b/tests/unit/DocumentationCoverage/DocStrCoverage.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 # Copyright 2023-2023 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #

--- a/tests/unit/DocumentationCoverage/__init__.py
+++ b/tests/unit/DocumentationCoverage/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/DataModel.py
+++ b/tests/unit/Unittesting/DataModel.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/Examples/OSVVM.py
+++ b/tests/unit/Unittesting/Examples/OSVVM.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/Examples/__init__.py
+++ b/tests/unit/Unittesting/Examples/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/Examples/pyAttributes.py
+++ b/tests/unit/Unittesting/Examples/pyAttributes.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/Examples/pyAttributes.py
+++ b/tests/unit/Unittesting/Examples/pyAttributes.py
@@ -42,7 +42,7 @@ if __name__ == "__main__": # pragma: no cover
 
 
 class PythonPyTest(TestCase):
-	def test_PyTest(self):
+	def test_PyTest(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyAttributes/pytest.pyAttributes.xml")

--- a/tests/unit/Unittesting/Examples/pyEDAAReports.py
+++ b/tests/unit/Unittesting/Examples/pyEDAAReports.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2021-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2021-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/Examples/pyEDAAReports.py
+++ b/tests/unit/Unittesting/Examples/pyEDAAReports.py
@@ -48,7 +48,7 @@ if __name__ == "__main__": # pragma: no cover
 
 
 class CppGoogleTest(TestCase):
-	def test_gtest(self):
+	def test_gtest(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/gtest.xml")
@@ -65,7 +65,7 @@ class CppGoogleTest(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/gtest.xml")
@@ -111,7 +111,7 @@ class CppGoogleTest(TestCase):
 
 
 class CppGoogleTestCTest(TestCase):
-	def test_ctest(self):
+	def test_ctest(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/ctest.xml")
@@ -128,7 +128,7 @@ class CppGoogleTestCTest(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Cpp-GoogleTest/ctest.xml")
@@ -174,7 +174,7 @@ class CppGoogleTestCTest(TestCase):
 
 
 class JavaAntJUnit4(TestCase):
-	def test_JUnit4(self):
+	def test_JUnit4(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Java-Ant-JUnit4/TEST-my.AllTests.xml")
@@ -191,7 +191,7 @@ class JavaAntJUnit4(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Java-Ant-JUnit4/TEST-my.AllTests.xml")
@@ -237,7 +237,7 @@ class JavaAntJUnit4(TestCase):
 
 
 class PythonPyTest(TestCase):
-	def test_Read(self):
+	def test_Read(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Python-pytest/TestReportSummary.xml")
@@ -259,7 +259,7 @@ class PythonPyTest(TestCase):
 		print(f"Statistics:")
 		print(f"  Times: parsing by lxml: {doc.AnalysisDuration.total_seconds():.3f}s   convert: {doc.ModelConversionDuration.total_seconds():.3f}s")
 
-	def test_ReadWrite(self):
+	def test_ReadWrite(self) -> None:
 		print()
 
 		junitExampleFile = Path("tests/data/JUnit/pyEDAA.Reports/Python-pytest/TestReportSummary.xml")

--- a/tests/unit/Unittesting/Examples/pyTooling.py
+++ b/tests/unit/Unittesting/Examples/pyTooling.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/Examples/pyVersioning.py
+++ b/tests/unit/Unittesting/Examples/pyVersioning.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/JUnit.py
+++ b/tests/unit/Unittesting/JUnit.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/Merge.py
+++ b/tests/unit/Unittesting/Merge.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/Unittesting/__init__.py
+++ b/tests/unit/Unittesting/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2024-2025 Electronic Design Automation Abstraction (EDA²)                                                  #
+# Copyright 2024-2026 Electronic Design Automation Abstraction (EDA²)                                                  #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,10 @@
--r ../requirements.txt
+-r ../../requirements.txt
+
+# Coverage collection
+Coverage ~= 7.13
+
+# Test Runner
+pytest ~= 9.0
+pytest-cov ~= 7.0
 
 docstr_coverage ~= 2.3


### PR DESCRIPTION
# Changes

* Bumped dependencies.
* Bumped copyright information.
* Updated pyproject settings due to pytest v9.0.


# Bug Fixes

* Fixed dependency to `pyTooling[terminal]`.
* Added missing type hints.
* Changed required versions from `0.X` to `0.X.0` so `~=` operator can work correctly.


# Unit Tests

* Updated pyTooling/Actions from `@r6` to `@r7`.
  * Restructured `requirements.txt` files.

-----
/cc @Weilanad