### PR TITLE
Document all properties and correct their decoration

### DIFF
--- a/pyEDAA/Reports/DocumentationCoverage/Python.py
+++ b/pyEDAA/Reports/DocumentationCoverage/Python.py
@@ -83,30 +83,65 @@ class Coverage(metaclass=ExtendedType, mixin=True):
 
 	@readonly
 	def Total(self) -> int:
+		"""
+		Read-only property to access the total number of documentable items.
+
+		:returns: Total number of items.
+		"""
 		return self._total
 
 	@readonly
 	def Excluded(self) -> int:
+		"""
+		Read-only property to access the number of items excluded from the analysis.
+
+		:returns: Number of excluded items.
+		"""
 		return self._excluded
 
 	@readonly
 	def Ignored(self) -> int:
+		"""
+		Read-only property to access the number of items ignored by the analysis.
+
+		:returns: Number of ignored items.
+		"""
 		return self._ignored
 
 	@readonly
 	def Expected(self) -> int:
+		"""
+		Read-only property to access the number of items expected to be documented.
+
+		:returns: Number of expected items.
+		"""
 		return self._expected
 
 	@readonly
 	def Covered(self) -> int:
+		"""
+		Read-only property to access the number of documented items.
+
+		:returns: Number of covered items.
+		"""
 		return self._covered
 
 	@readonly
 	def Uncovered(self) -> int:
+		"""
+		Read-only property to access the number of undocumented items.
+
+		:returns: Number of uncovered items.
+		"""
 		return self._uncovered
 
 	@readonly
 	def Coverage(self) -> float:
+		"""
+		Read-only property to access the ratio of covered to expected items.
+
+		:returns: Documentation coverage in the range 0.0 to 1.0.
+		"""
 		return self._coverage
 
 	def CalculateCoverage(self) -> None:
@@ -178,34 +213,74 @@ class AggregatedCoverage(Coverage, mixin=True):
 
 	@readonly
 	def File(self) -> Path:
+		"""
+		Read-only property to access the file this coverage was computed from.
+
+		:returns: Path to the analyzed file.
+		"""
 		return self._file
 
 	@readonly
 	def AggregatedTotal(self) -> int:
+		"""
+		Read-only property to access the total number of documentable items, including all children.
+
+		:returns: Aggregated total number of items.
+		"""
 		return self._aggregatedTotal
 
 	@readonly
 	def AggregatedExcluded(self) -> int:
+		"""
+		Read-only property to access the number of excluded items, including all children.
+
+		:returns: Aggregated number of excluded items.
+		"""
 		return self._aggregatedExcluded
 
 	@readonly
 	def AggregatedIgnored(self) -> int:
+		"""
+		Read-only property to access the number of ignored items, including all children.
+
+		:returns: Aggregated number of ignored items.
+		"""
 		return self._aggregatedIgnored
 
 	@readonly
 	def AggregatedExpected(self) -> int:
+		"""
+		Read-only property to access the number of expected items, including all children.
+
+		:returns: Aggregated number of expected items.
+		"""
 		return self._aggregatedExpected
 
 	@readonly
 	def AggregatedCovered(self) -> int:
+		"""
+		Read-only property to access the number of documented items, including all children.
+
+		:returns: Aggregated number of covered items.
+		"""
 		return self._aggregatedCovered
 
 	@readonly
 	def AggregatedUncovered(self) -> int:
+		"""
+		Read-only property to access the number of undocumented items, including all children.
+
+		:returns: Aggregated number of uncovered items.
+		"""
 		return self._aggregatedUncovered
 
 	@readonly
 	def AggregatedCoverage(self) -> float:
+		"""
+		Read-only property to access the coverage ratio, including all children.
+
+		:returns: Aggregated documentation coverage in the range 0.0 to 1.0.
+		"""
 		return self._aggregatedCoverage
 
 	def Aggregate(self) -> None:
@@ -237,14 +312,29 @@ class ClassCoverage(Class, Coverage):
 
 	@readonly
 	def Fields(self) -> Dict[str, CoverageState]:
+		"""
+		Read-only property to access the coverage states of the class' fields.
+
+		:returns: Dictionary of field names and their coverage states.
+		"""
 		return self._fields
 
 	@readonly
 	def Methods(self) -> Dict[str, CoverageState]:
+		"""
+		Read-only property to access the coverage states of the class' methods.
+
+		:returns: Dictionary of method names and their coverage states.
+		"""
 		return self._methods
 
 	@readonly
 	def Classes(self) -> Dict[str, "ClassCoverage"]:
+		"""
+		Read-only property to access the class' nested classes.
+
+		:returns: Dictionary of class names and their coverage.
+		"""
 		return self._classes
 
 	def CalculateCoverage(self) -> None:
@@ -286,14 +376,29 @@ class ModuleCoverage(Module, AggregatedCoverage):
 
 	@readonly
 	def Variables(self) -> Dict[str, CoverageState]:
+		"""
+		Read-only property to access the coverage states of the module's variables.
+
+		:returns: Dictionary of variable names and their coverage states.
+		"""
 		return self._variables
 
 	@readonly
 	def Functions(self) -> Dict[str, CoverageState]:
+		"""
+		Read-only property to access the coverage states of the module's functions.
+
+		:returns: Dictionary of function names and their coverage states.
+		"""
 		return self._functions
 
 	@readonly
 	def Classes(self) -> Dict[str, ClassCoverage]:
+		"""
+		Read-only property to access the module's classes.
+
+		:returns: Dictionary of class names and their coverage.
+		"""
 		return self._classes
 
 	def CalculateCoverage(self) -> None:
@@ -359,26 +464,56 @@ class PackageCoverage(Package, AggregatedCoverage):
 
 	@readonly
 	def FileCount(self) -> int:
+		"""
+		Read-only property to access the number of Python files in this package.
+
+		:returns: Number of files.
+		"""
 		return self._fileCount
 
 	@readonly
 	def Variables(self) -> Dict[str, CoverageState]:
+		"""
+		Read-only property to access the coverage states of the package's variables.
+
+		:returns: Dictionary of variable names and their coverage states.
+		"""
 		return self._variables
 
 	@readonly
 	def Functions(self) -> Dict[str, CoverageState]:
+		"""
+		Read-only property to access the coverage states of the package's functions.
+
+		:returns: Dictionary of function names and their coverage states.
+		"""
 		return self._functions
 
 	@readonly
 	def Classes(self) -> Dict[str, ClassCoverage]:
+		"""
+		Read-only property to access the package's classes.
+
+		:returns: Dictionary of class names and their coverage.
+		"""
 		return self._classes
 
 	@readonly
 	def Modules(self) -> Dict[str, ModuleCoverage]:
+		"""
+		Read-only property to access the package's modules.
+
+		:returns: Dictionary of module names and their coverage.
+		"""
 		return self._modules
 
 	@readonly
 	def Packages(self) -> Dict[str, "PackageCoverage"]:
+		"""
+		Read-only property to access the package's sub-packages.
+
+		:returns: Dictionary of package names and their coverage.
+		"""
 		return self._packages
 
 	def __getitem__(self, key: str) -> Union["PackageCoverage", ModuleCoverage]:
@@ -464,18 +599,38 @@ class DocStrCoverage(metaclass=ExtendedType):
 
 	@readonly
 	def SearchDirectories(self) -> Path:
+		"""
+		Read-only property to access the directory the analysis searches for Python files.
+
+		:returns: Path to the search directory.
+		"""
 		return self._searchDirectory
 
 	@readonly
 	def PackageName(self) -> str:
+		"""
+		Read-only property to access the name of the analyzed package.
+
+		:returns: Name of the package.
+		"""
 		return self._packageName
 
 	@readonly
 	def ModuleFiles(self) -> List[Path]:
+		"""
+		Read-only property to access the Python files found in the search directory.
+
+		:returns: List of module file paths.
+		"""
 		return self._moduleFiles
 
 	@readonly
 	def CoverageReport(self) -> ResultCollection:
+		"""
+		Read-only property to access the raw report produced by ``docstr_coverage``.
+
+		:returns: The analyzer's result collection.
+		"""
 		return self._coverageReport
 
 	def Analyze(self) -> ResultCollection:

--- a/pyEDAA/Reports/DocumentationCoverage/__init__.py
+++ b/pyEDAA/Reports/DocumentationCoverage/__init__.py
@@ -32,7 +32,7 @@
 from enum                  import Flag
 from typing                import Optional as Nullable
 
-from pyTooling.Decorators  import export
+from pyTooling.Decorators  import export, readonly
 from pyTooling.MetaClasses import ExtendedType
 
 from pyEDAA.Reports        import ReportException
@@ -82,16 +82,31 @@ class Base(metaclass=ExtendedType, slots=True):
 		self._name = name
 		self._status = CoverageState.Unknown
 
-	@property
+	@readonly
 	def Parent(self) -> Nullable["Base"]:
+		"""
+		Read-only property to access the reference to the parent coverage entity.
+
+		:returns: Reference to the parent entity, or ``None`` for the root entity.
+		"""
 		return self._parent
 
-	@property
+	@readonly
 	def Name(self) -> str:
+		"""
+		Read-only property to access the coverage entity's name.
+
+		:returns: Name of the coverage entity.
+		"""
 		return self._name
 
-	@property
+	@readonly
 	def Status(self) -> CoverageState:
+		"""
+		Read-only property to access the coverage entity's state.
+
+		:returns: Coverage state of the entity.
+		"""
 		return self._status
 
 

--- a/pyEDAA/Reports/Unittesting/JUnit/__init__.py
+++ b/pyEDAA/Reports/Unittesting/JUnit/__init__.py
@@ -215,7 +215,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def Parent(self) -> Nullable["Testsuite"]:
 		"""
-		Read-only property returning the reference to the parent test entity.
+		Read-only property to access the reference to the parent test entity.
 
 		:returns: Reference to the parent entity.
 		"""
@@ -226,7 +226,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def Name(self) -> str:
 		"""
-		Read-only property returning the test entity's name.
+		Read-only property to access the test entity's name.
 
 		:returns: Name of the test entity.
 		"""
@@ -286,7 +286,7 @@ class BaseWithProperties(Base):
 	@readonly
 	def Duration(self) -> timedelta:
 		"""
-		Read-only property returning the duration of a test entity run.
+		Read-only property to access the duration of a test entity run.
 
 		.. note::
 
@@ -300,7 +300,7 @@ class BaseWithProperties(Base):
 	@abstractmethod
 	def AssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of assertions (checks) in a test case.
+		Read-only property to access the number of assertions (checks) in a test case.
 
 		.. note::
 
@@ -429,7 +429,7 @@ class Testcase(BaseWithProperties):
 	@readonly
 	def Classname(self) -> str:
 		"""
-		Read-only property returning the class name of the test case.
+		Read-only property to access the class name of the test case.
 
 		:returns: The test case's class name.
 
@@ -446,7 +446,7 @@ class Testcase(BaseWithProperties):
 	@readonly
 	def Status(self) -> TestcaseStatus:
 		"""
-		Read-only property returning the status of the test case.
+		Read-only property to access the status of the test case.
 
 		:returns: The test case's status.
 		"""
@@ -455,7 +455,7 @@ class Testcase(BaseWithProperties):
 	@readonly
 	def AssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of assertions (checks) in a test case.
+		Read-only property to return the number of assertions (checks) in a test case.
 
 		.. note::
 
@@ -587,35 +587,75 @@ class TestsuiteBase(BaseWithProperties):
 
 	@readonly
 	def StartTime(self) -> Nullable[datetime]:
+		"""
+		Read-only property to access the time the test entity's execution started.
+
+		:returns: Start time of the execution, or ``None`` if it wasn't recorded.
+		"""
 		return self._startTime
 
 	@readonly
 	def Status(self) -> TestsuiteStatus:
+		"""
+		Read-only property to access the test entity's aggregated status.
+
+		:returns: Status of the test entity.
+		"""
 		return self._status
 
 	@readonly
 	@mustoverride
 	def TestcaseCount(self) -> int:
+		"""
+		Read-only property to access the number of testcases in this entity.
+
+		:returns: Number of testcases.
+		"""
 		pass
 
 	@readonly
 	def Tests(self) -> int:
+		"""
+		Read-only property to access the number of testcases in this entity.
+
+		:returns: Number of testcases.
+		"""
 		return self.TestcaseCount
 
 	@readonly
 	def Skipped(self) -> int:
+		"""
+		Read-only property to access the number of skipped testcases.
+
+		:returns: Number of skipped testcases.
+		"""
 		return self._skipped
 
 	@readonly
 	def Errored(self) -> int:
+		"""
+		Read-only property to access the number of errored testcases.
+
+		:returns: Number of errored testcases.
+		"""
 		return self._errored
 
 	@readonly
 	def Failed(self) -> int:
+		"""
+		Read-only property to access the number of failed testcases.
+
+		:returns: Number of failed testcases.
+		"""
 		return self._failed
 
 	@readonly
 	def Passed(self) -> int:
+		"""
+		Read-only property to access the number of passed testcases.
+
+		:returns: Number of passed testcases.
+		"""
 		return self._passed
 
 	def Aggregate(self) -> TestsuiteAggregateReturnType:
@@ -693,7 +733,7 @@ class Testclass(Base):
 	@readonly
 	def Classname(self) -> str:
 		"""
-		Read-only property returning the name of the test class.
+		Read-only property to access the name of the test class.
 
 		:returns: The test class' name.
 		"""
@@ -702,7 +742,7 @@ class Testclass(Base):
 	@readonly
 	def Testcases(self) -> Dict[str, "Testcase"]:
 		"""
-		Read-only property returning a reference to the internal dictionary of test cases.
+		Read-only property to access a reference to the internal dictionary of test cases.
 
 		:returns: Reference to the dictionary of test cases.
 		"""
@@ -711,7 +751,7 @@ class Testclass(Base):
 	@readonly
 	def TestcaseCount(self) -> int:
 		"""
-		Read-only property returning the number of all test cases in the test entity hierarchy.
+		Read-only property to return the number of all test cases in the test entity hierarchy.
 
 		:returns: Number of test cases.
 		"""
@@ -719,6 +759,11 @@ class Testclass(Base):
 
 	@readonly
 	def AssertionCount(self) -> int:
+		"""
+		Read-only property to return the number of assertions across all testcases of this testclass.
+
+		:returns: Sum of the testcases' assertion counts.
+		"""
 		return sum(tc.AssertionCount for tc in self._testcases.values())
 
 	def AddTestcase(self, testcase: "Testcase") -> None:
@@ -822,14 +867,29 @@ class Testsuite(TestsuiteBase):
 
 	@readonly
 	def Hostname(self) -> Nullable[str]:
+		"""
+		Read-only property to access the host the testsuite was executed on.
+
+		:returns: Hostname, or ``None`` if it wasn't recorded.
+		"""
 		return self._hostname
 
 	@readonly
 	def Testclasses(self) -> Dict[str, "Testclass"]:
+		"""
+		Read-only property to access the testsuite's testclasses.
+
+		:returns: Dictionary of testclass names and testclasses.
+		"""
 		return self._testclasses
 
 	@readonly
 	def TestclassCount(self) -> int:
+		"""
+		Read-only property to return the number of testclasses in this testsuite.
+
+		:returns: Number of testclasses.
+		"""
 		return len(self._testclasses)
 
 	# @readonly
@@ -838,10 +898,20 @@ class Testsuite(TestsuiteBase):
 
 	@readonly
 	def TestcaseCount(self) -> int:
+		"""
+		Read-only property to return the number of testcases across all testclasses.
+
+		:returns: Sum of the testclasses' testcase counts.
+		"""
 		return sum(cls.TestcaseCount for cls in self._testclasses.values())
 
 	@readonly
 	def AssertionCount(self) -> int:
+		"""
+		Read-only property to return the number of assertions across all testclasses.
+
+		:returns: Sum of the testclasses' assertion counts.
+		"""
 		return sum(cls.AssertionCount for cls in self._testclasses.values())
 
 	def AddTestclass(self, testclass: "Testclass") -> None:
@@ -1062,18 +1132,38 @@ class TestsuiteSummary(TestsuiteBase):
 
 	@readonly
 	def Testsuites(self) -> Dict[str, Testsuite]:
+		"""
+		Read-only property to access the summary's testsuites.
+
+		:returns: Dictionary of testsuite names and testsuites.
+		"""
 		return self._testsuites
 
 	@readonly
 	def TestcaseCount(self) -> int:
+		"""
+		Read-only property to return the number of testcases across all testsuites.
+
+		:returns: Sum of the testsuites' testcase counts.
+		"""
 		return sum(ts.TestcaseCount for ts in self._testsuites.values())
 
 	@readonly
 	def TestsuiteCount(self) -> int:
+		"""
+		Read-only property to return the number of testsuites in this summary.
+
+		:returns: Number of testsuites.
+		"""
 		return len(self._testsuites)
 
 	@readonly
 	def AssertionCount(self) -> int:
+		"""
+		Read-only property to return the number of assertions across all testsuites.
+
+		:returns: Sum of the testsuites' assertion counts.
+		"""
 		return sum(ts.AssertionCount for ts in self._testsuites.values())
 
 	def AddTestsuite(self, testsuite: Testsuite) -> None:

--- a/pyEDAA/Reports/Unittesting/__init__.py
+++ b/pyEDAA/Reports/Unittesting/__init__.py
@@ -478,7 +478,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def Parent(self) -> Nullable["TestsuiteBase"]:
 		"""
-		Read-only property returning the reference to the parent test entity.
+		Read-only property to access the reference to the parent test entity.
 
 		:returns: Reference to the parent entity.
 		"""
@@ -487,7 +487,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def Name(self) -> str:
 		"""
-		Read-only property returning the test entity's name.
+		Read-only property to access the test entity's name.
 
 		:returns: The test entities name.
 		"""
@@ -496,7 +496,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def StartTime(self) -> Nullable[datetime]:
 		"""
-		Read-only property returning the time when the test entity was started.
+		Read-only property to access the time when the test entity was started.
 
 		:returns: Time when the test entity was started.
 		"""
@@ -505,7 +505,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def SetupDuration(self) -> Nullable[timedelta]:
 		"""
-		Read-only property returning the duration of the test entity's setup.
+		Read-only property to access the duration of the test entity's setup.
 
 		:returns: Duration it took to set up the entity.
 		"""
@@ -514,7 +514,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def TestDuration(self) -> Nullable[timedelta]:
 		"""
-		Read-only property returning the duration of a test entities run.
+		Read-only property to access the duration of a test entities run.
 
 		This duration is excluding setup and teardown durations. In case setup and/or teardown durations are unknown or not
 		distinguishable, assign setup and teardown durations with zero.
@@ -526,7 +526,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def TeardownDuration(self) -> Nullable[timedelta]:
 		"""
-		Read-only property returning the duration of the test entity's teardown.
+		Read-only property to access the duration of the test entity's teardown.
 
 		:returns: Duration it took to tear down the entity.
 		"""
@@ -535,7 +535,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def TotalDuration(self) -> Nullable[timedelta]:
 		"""
-		Read-only property returning the total duration of a test entity run.
+		Read-only property to access the total duration of a test entity run.
 
 		this duration includes setup and teardown durations.
 
@@ -546,7 +546,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def WarningCount(self) -> int:
 		"""
-		Read-only property returning the number of encountered warnings.
+		Read-only property to access the number of encountered warnings.
 
 		:returns: Count of encountered warnings.
 		"""
@@ -555,7 +555,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def ErrorCount(self) -> int:
 		"""
-		Read-only property returning the number of encountered errors.
+		Read-only property to access the number of encountered errors.
 
 		:returns: Count of encountered errors.
 		"""
@@ -564,7 +564,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def FatalCount(self) -> int:
 		"""
-		Read-only property returning the number of encountered fatal errors.
+		Read-only property to access the number of encountered fatal errors.
 
 		:returns: Count of encountered fatal errors.
 		"""
@@ -573,7 +573,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def ExpectedWarningCount(self) -> int:
 		"""
-		Read-only property returning the number of expected warnings.
+		Read-only property to access the number of expected warnings.
 
 		:returns: Count of expected warnings.
 		"""
@@ -582,7 +582,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def ExpectedErrorCount(self) -> int:
 		"""
-		Read-only property returning the number of expected errors.
+		Read-only property to access the number of expected errors.
 
 		:returns: Count of expected errors.
 		"""
@@ -591,7 +591,7 @@ class Base(metaclass=ExtendedType, slots=True):
 	@readonly
 	def ExpectedFatalCount(self) -> int:
 		"""
-		Read-only property returning the number of expected fatal errors.
+		Read-only property to access the number of expected fatal errors.
 
 		:returns: Count of expected fatal errors.
 		"""
@@ -803,7 +803,7 @@ class Testcase(Base):
 	@readonly
 	def Status(self) -> TestcaseStatus:
 		"""
-		Read-only property returning the status of the test case.
+		Read-only property to access the status of the test case.
 
 		:returns: The test case's status.
 		"""
@@ -812,7 +812,7 @@ class Testcase(Base):
 	@readonly
 	def AssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of assertions (checks) in a test case.
+		Read-only property to return the number of assertions (checks) in a test case.
 
 		:returns: Number of assertions.
 		"""
@@ -823,7 +823,7 @@ class Testcase(Base):
 	@readonly
 	def FailedAssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of failed assertions (failed checks) in a test case.
+		Read-only property to access the number of failed assertions (failed checks) in a test case.
 
 		:returns: Number of assertions.
 		"""
@@ -832,7 +832,7 @@ class Testcase(Base):
 	@readonly
 	def PassedAssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of passed assertions (successful checks) in a test case.
+		Read-only property to access the number of passed assertions (successful checks) in a test case.
 
 		:returns: Number of passed assertions.
 		"""
@@ -1029,7 +1029,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Kind(self) -> TestsuiteKind:
 		"""
-		Read-only property returning the kind of the test suite.
+		Read-only property to access the kind of the test suite.
 
 		Test suites are used to group test cases. This grouping can be due to language/framework specifics like tests
 		grouped by a module file or namespace. Others might be just logically grouped without any relation to a programming
@@ -1044,7 +1044,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Status(self) -> TestsuiteStatus:
 		"""
-		Read-only property returning the aggregated overall status of the test suite.
+		Read-only property to access the aggregated overall status of the test suite.
 
 		:returns: Overall status of the test suite.
 		"""
@@ -1053,7 +1053,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Testsuites(self) -> Dict[str, TestsuiteType]:
 		"""
-		Read-only property returning a reference to the internal dictionary of test suites.
+		Read-only property to access a reference to the internal dictionary of test suites.
 
 		:returns: Reference to the dictionary of test suite.
 		"""
@@ -1062,7 +1062,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def TestsuiteCount(self) -> int:
 		"""
-		Read-only property returning the number of all test suites in the test suite hierarchy.
+		Read-only property to return the number of all test suites in the test suite hierarchy.
 
 		:returns: Number of test suites.
 		"""
@@ -1071,7 +1071,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def TestcaseCount(self) -> int:
 		"""
-		Read-only property returning the number of all test cases in the test entity hierarchy.
+		Read-only property to return the number of all test cases in the test entity hierarchy.
 
 		:returns: Number of test cases.
 		"""
@@ -1080,7 +1080,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def AssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of all assertions in all test cases in the test entity hierarchy.
+		Read-only property to return the number of all assertions in all test cases in the test entity hierarchy.
 
 		:returns: Number of assertions in all test cases.
 		"""
@@ -1089,7 +1089,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def FailedAssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of all failed assertions in all test cases in the test entity hierarchy.
+		Read-only property to access the number of all failed assertions in all test cases in the test entity hierarchy.
 
 		:returns: Number of failed assertions in all test cases.
 		"""
@@ -1099,7 +1099,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def PassedAssertionCount(self) -> int:
 		"""
-		Read-only property returning the number of all passed assertions in all test cases in the test entity hierarchy.
+		Read-only property to access the number of all passed assertions in all test cases in the test entity hierarchy.
 
 		:returns: Number of passed assertions in all test cases.
 		"""
@@ -1108,12 +1108,17 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 
 	@readonly
 	def Tests(self) -> int:
+		"""
+		Read-only property to access the number of tests in this entity.
+
+		:returns: Number of tests.
+		"""
 		return self._tests
 
 	@readonly
 	def Inconsistent(self) -> int:
 		"""
-		Read-only property returning the number of inconsistent tests in the test suite hierarchy.
+		Read-only property to access the number of inconsistent tests in the test suite hierarchy.
 
 		:returns: Number of inconsistent tests.
 		"""
@@ -1122,7 +1127,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Excluded(self) -> int:
 		"""
-		Read-only property returning the number of excluded tests in the test suite hierarchy.
+		Read-only property to access the number of excluded tests in the test suite hierarchy.
 
 		:returns: Number of excluded tests.
 		"""
@@ -1131,7 +1136,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Skipped(self) -> int:
 		"""
-		Read-only property returning the number of skipped tests in the test suite hierarchy.
+		Read-only property to access the number of skipped tests in the test suite hierarchy.
 
 		:returns: Number of skipped tests.
 		"""
@@ -1140,7 +1145,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Errored(self) -> int:
 		"""
-		Read-only property returning the number of tests with errors in the test suite hierarchy.
+		Read-only property to access the number of tests with errors in the test suite hierarchy.
 
 		:returns: Number of errored tests.
 		"""
@@ -1149,7 +1154,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Weak(self) -> int:
 		"""
-		Read-only property returning the number of weak tests in the test suite hierarchy.
+		Read-only property to access the number of weak tests in the test suite hierarchy.
 
 		:returns: Number of weak tests.
 		"""
@@ -1158,7 +1163,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Failed(self) -> int:
 		"""
-		Read-only property returning the number of failed tests in the test suite hierarchy.
+		Read-only property to access the number of failed tests in the test suite hierarchy.
 
 		:returns: Number of failed tests.
 		"""
@@ -1167,7 +1172,7 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 	@readonly
 	def Passed(self) -> int:
 		"""
-		Read-only property returning the number of passed tests in the test suite hierarchy.
+		Read-only property to access the number of passed tests in the test suite hierarchy.
 
 		:returns: Number of passed tests.
 		"""
@@ -1175,16 +1180,31 @@ class TestsuiteBase(Base, Generic[TestsuiteType]):
 
 	@readonly
 	def WarningCount(self) -> int:
+		"""
+		Read-only property to access the number of warnings in this entity.
+
+		:returns: Number of warnings.
+		"""
 		raise NotImplementedError()
 		# return self._warningCount
 
 	@readonly
 	def ErrorCount(self) -> int:
+		"""
+		Read-only property to access the number of errors in this entity.
+
+		:returns: Number of errors.
+		"""
 		raise NotImplementedError()
 		# return self._errorCount
 
 	@readonly
 	def FatalCount(self) -> int:
+		"""
+		Read-only property to access the number of fatal errors in this entity.
+
+		:returns: Number of fatal errors.
+		"""
 		raise NotImplementedError()
 		# return self._fatalCount
 
@@ -1406,7 +1426,7 @@ class Testsuite(TestsuiteBase[TestsuiteType]):
 	@readonly
 	def Testcases(self) -> Dict[str, "Testcase"]:
 		"""
-		Read-only property returning a reference to the internal dictionary of test cases.
+		Read-only property to access a reference to the internal dictionary of test cases.
 
 		:returns: Reference to the dictionary of test cases.
 		"""
@@ -1415,7 +1435,7 @@ class Testsuite(TestsuiteBase[TestsuiteType]):
 	@readonly
 	def TestcaseCount(self) -> int:
 		"""
-		Read-only property returning the number of all test cases in the test entity hierarchy.
+		Read-only property to return the number of all test cases in the test entity hierarchy.
 
 		:returns: Number of test cases.
 		"""
@@ -1423,6 +1443,11 @@ class Testsuite(TestsuiteBase[TestsuiteType]):
 
 	@readonly
 	def AssertionCount(self) -> int:
+		"""
+		Read-only property to return the number of assertions in this testsuite and its testcases.
+
+		:returns: Sum of the inherited assertion count and the testcases' assertion counts.
+		"""
 		return super().AssertionCount + sum(tc.AssertionCount for tc in self._testcases.values())
 
 	def Copy(self) -> "Testsuite":
@@ -1728,7 +1753,7 @@ class Document(metaclass=ExtendedType, mixin=True):
 	@readonly
 	def AnalysisDuration(self) -> timedelta:
 		"""
-		Read-only property returning analysis duration.
+		Read-only property to return analysis duration.
 
 		.. note::
 
@@ -1742,7 +1767,7 @@ class Document(metaclass=ExtendedType, mixin=True):
 	@readonly
 	def ModelConversionDuration(self) -> timedelta:
 		"""
-		Read-only property returning conversion duration.
+		Read-only property to return conversion duration.
 
 		.. note::
 
@@ -1777,6 +1802,11 @@ class Merged(metaclass=ExtendedType, mixin=True):
 
 	@readonly
 	def MergedCount(self) -> int:
+		"""
+		Read-only property to access how many source entities were merged into this one.
+
+		:returns: Number of merged entities.
+		"""
 		return self._mergedCount
 
 
@@ -1789,6 +1819,11 @@ class Combined(metaclass=ExtendedType, mixin=True):
 
 	@readonly
 	def CombinedCount(self) -> int:
+		"""
+		Read-only property to access how many source entities were combined into this one.
+
+		:returns: Number of combined entities.
+		"""
 		return self._combinedCount
 
 
@@ -1820,6 +1855,11 @@ class MergedTestcase(Testcase, Merged):
 
 	@readonly
 	def Status(self) -> TestcaseStatus:
+		"""
+		Read-only property to access the status merged from all source testcases.
+
+		:returns: Merged status. ``TestcaseStatus.Inconsistent`` if the sources disagree.
+		"""
 		if self._status is TestcaseStatus.Unknown:
 			status = self._mergedTestcases[0]._status
 			for mtc in self._mergedTestcases[1:]:
@@ -1831,14 +1871,29 @@ class MergedTestcase(Testcase, Merged):
 
 	@readonly
 	def SummedAssertionCount(self) -> int:
+		"""
+		Read-only property to return the number of assertions across all merged testcases.
+
+		:returns: Sum of the merged testcases' assertion counts.
+		"""
 		return sum(tc._assertionCount for tc in self._mergedTestcases)
 
 	@readonly
 	def SummedPassedAssertionCount(self) -> int:
+		"""
+		Read-only property to return the number of passed assertions across all merged testcases.
+
+		:returns: Sum of the merged testcases' passed assertion counts.
+		"""
 		return sum(tc._passedAssertionCount for tc in self._mergedTestcases)
 
 	@readonly
 	def SummedFailedAssertionCount(self) -> int:
+		"""
+		Read-only property to return the number of failed assertions across all merged testcases.
+
+		:returns: Sum of the merged testcases' failed assertion counts.
+		"""
 		return sum(tc._failedAssertionCount for tc in self._mergedTestcases)
 
 	def Aggregate(self, strict: bool = True) -> TestcaseAggregateReturnType:


### PR DESCRIPTION
> **Stacked on #153.** Its base is `claude/pytooling-8.18-compatibility`, not `dev`, because both branches touch the same files. Merge #153 first and this one's diff collapses to just the property changes.

# New Features

* tbd

# Changes

* `pyEDAA.Reports.DocumentationCoverage`:
  * `Base.Parent`, `Base.Name` and `Base.Status` are marked `@readonly`. They had no setter and no deleter anywhere in the class, so they were read-only in fact but not marked as such. Every other read-only property in the package already used `@readonly`.

# Bug Fixes

* tbd

# Documentation

* All 110 properties now carry a doc-string with a `:returns:` field. **63 had none at all**:

  | Module | Undocumented |
  |---|---|
  | `DocumentationCoverage/Python.py` | 31 |
  | `Unittesting/JUnit/__init__.py` | 18 |
  | `Unittesting/__init__.py` | 11 |
  | `DocumentationCoverage/__init__.py` | 3 |

* Wording follows **pyTooling** rather than this repository's previous phrasing, so the pyEDAA projects head in the same direction:
  * `Read-only property to access ...` when the body is a plain field access — an attribute chain rooted at `self` or `cls`.
  * `Read-only property to return ...` when the value is computed — `len(...)`, `sum(...)`, a comprehension or a call.

  The 47 pre-existing doc-strings said `Read-only property returning ...`, so they were converted too: **109 summaries** in total, classified by AST rather than by eye — 83 accessors, 20 computed, 7 abstract. There are no boolean properties here, so pyTooling's `Check if ...` form doesn't arise.

* An audit now reports zero undocumented properties, zero without `:returns:`, zero `@property` without a setter and zero `@readonly` with one.

# Unit Tests

* No test changes. 86 passed, unchanged.

----------
# Related Issues and Pull-Requests

* #153
